### PR TITLE
Feat# DM 기능과 거래 기능 연동 및 거래로직 종결 구현

### DIFF
--- a/src/main/generated/org/example/bookmarket/admin/banner/entity/QBanner.java
+++ b/src/main/generated/org/example/bookmarket/admin/banner/entity/QBanner.java
@@ -1,4 +1,4 @@
-package org.example.bookmarket.banner.entity;
+package org.example.bookmarket.admin.banner.entity;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
@@ -15,7 +15,7 @@ import com.querydsl.core.types.Path;
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QBanner extends EntityPathBase<Banner> {
 
-    private static final long serialVersionUID = -40305456L;
+    private static final long serialVersionUID = -344154673L;
 
     public static final QBanner banner = new QBanner("banner");
 

--- a/src/main/generated/org/example/bookmarket/admin/specialaccount/entity/QSpecialAccount.java
+++ b/src/main/generated/org/example/bookmarket/admin/specialaccount/entity/QSpecialAccount.java
@@ -1,0 +1,49 @@
+package org.example.bookmarket.admin.specialaccount.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QSpecialAccount is a Querydsl query type for SpecialAccount
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QSpecialAccount extends EntityPathBase<SpecialAccount> {
+
+    private static final long serialVersionUID = -1534309633L;
+
+    public static final QSpecialAccount specialAccount = new QSpecialAccount("specialAccount");
+
+    public final org.example.bookmarket.common.QTimeEntity _super = new org.example.bookmarket.common.QTimeEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath nickname = createString("nickname");
+
+    public final EnumPath<SpecialAccountStatus> status = createEnum("status", SpecialAccountStatus.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QSpecialAccount(String variable) {
+        super(SpecialAccount.class, forVariable(variable));
+    }
+
+    public QSpecialAccount(Path<? extends SpecialAccount> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QSpecialAccount(PathMetadata metadata) {
+        super(SpecialAccount.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/org/example/bookmarket/trade/entity/QTrade.java
+++ b/src/main/generated/org/example/bookmarket/trade/entity/QTrade.java
@@ -28,20 +28,14 @@ public class QTrade extends EntityPathBase<Trade> {
 
     public final org.example.bookmarket.user.entity.QUser buyer;
 
-    public final StringPath buyerContactInfo = createString("buyerContactInfo");
+    public final org.example.bookmarket.chat.entity.QChatChannel channel;
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
 
-    public final StringPath deliveryAddress = createString("deliveryAddress");
-
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
-    public final StringPath pickupLocation = createString("pickupLocation");
-
     public final org.example.bookmarket.user.entity.QUser seller;
-
-    public final StringPath sellerContactInfo = createString("sellerContactInfo");
 
     public final EnumPath<TradeStatus> status = createEnum("status", TradeStatus.class);
 
@@ -71,6 +65,7 @@ public class QTrade extends EntityPathBase<Trade> {
     public QTrade(Class<? extends Trade> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
         this.buyer = inits.isInitialized("buyer") ? new org.example.bookmarket.user.entity.QUser(forProperty("buyer")) : null;
+        this.channel = inits.isInitialized("channel") ? new org.example.bookmarket.chat.entity.QChatChannel(forProperty("channel"), inits.get("channel")) : null;
         this.seller = inits.isInitialized("seller") ? new org.example.bookmarket.user.entity.QUser(forProperty("seller")) : null;
         this.usedBook = inits.isInitialized("usedBook") ? new org.example.bookmarket.usedbook.entity.QUsedBook(forProperty("usedBook"), inits.get("usedBook")) : null;
     }

--- a/src/main/java/org/example/bookmarket/book/controller/BookPageController.java
+++ b/src/main/java/org/example/bookmarket/book/controller/BookPageController.java
@@ -17,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -110,5 +111,20 @@ public class BookPageController {
         usedBookPostService.registerUsedBook(request);
         // 등록 성공 후 마이페이지의 판매 목록으로 리다이렉트
         return "redirect:/profile/me";
+    }
+
+    @GetMapping("/used-books/{bookId}/edit")
+    public String editBookForm(@PathVariable Long bookId,
+                               Model model,
+                               RedirectAttributes redirectAttributes) {
+        UsedBookResponse book = usedBookQueryService.getUsedBookById(bookId);
+        if ("판매 완료".equalsIgnoreCase(book.status()) || "SOLD".equalsIgnoreCase(book.status())) {
+            redirectAttributes.addFlashAttribute("alertMessage", "판매 완료된 책은 수정할 수 없습니다.");
+            return "redirect:/used-books/" + bookId;
+        }
+        List<CategoryResponse> categories = categoryService.getAllCategories();
+        model.addAttribute("book", book);
+        model.addAttribute("categories", categories);
+        return "book-edit";
     }
 }

--- a/src/main/java/org/example/bookmarket/chat/controller/ChatController.java
+++ b/src/main/java/org/example/bookmarket/chat/controller/ChatController.java
@@ -69,6 +69,9 @@ public class ChatController {
         model.addAttribute("partnerNickname", chatRoomInfo.getPartnerNickname());
         model.addAttribute("bookTitle", chatRoomInfo.getBookTitle());
         model.addAttribute("bookUrl", "/used-books/" + chatRoomInfo.getBookId());
+        model.addAttribute("isSeller", chatRoomInfo.isSeller());
+        model.addAttribute("tradeStatus", chatRoomInfo.getTradeStatus());
+        model.addAttribute("initialPrice", chatRoomInfo.getInitialPrice());
 
         return "chatroom";
     }
@@ -89,6 +92,31 @@ public class ChatController {
     @ResponseBody
     public List<ChatMessageResponse> getMessages(@PathVariable Long channelId) {
         return chatService.getMessages(channelId);
+    }
+
+    @PostMapping("/channel/{channelId}/complete")
+    @ResponseStatus(HttpStatus.OK)
+    @ResponseBody
+    public void complete(@PathVariable Long channelId,
+                         @RequestParam Integer price,
+                         Authentication authentication) {
+        User currentUser = resolveCurrentUser(authentication);
+        if (currentUser == null) {
+            throw new CustomException(ErrorCode.LOGIN_REQUIRED);
+        }
+        chatService.completeTrade(channelId, price, currentUser.getId());
+    }
+
+    @PostMapping("/channel/{channelId}/cancel")
+    @ResponseStatus(HttpStatus.OK)
+    @ResponseBody
+    public void cancel(@PathVariable Long channelId,
+                       Authentication authentication) {
+        User currentUser = resolveCurrentUser(authentication);
+        if (currentUser == null) {
+            throw new CustomException(ErrorCode.LOGIN_REQUIRED);
+        }
+        chatService.cancelTrade(channelId, currentUser.getId());
     }
 
     @DeleteMapping("/message/{messageId}")

--- a/src/main/java/org/example/bookmarket/chat/dto/ChatRoomInfo.java
+++ b/src/main/java/org/example/bookmarket/chat/dto/ChatRoomInfo.java
@@ -9,4 +9,7 @@ public class ChatRoomInfo {
     private String partnerNickname;
     private String bookTitle;
     private Long bookId; // "책 보러가기" 링크를 위해 추가
+    private boolean seller;
+    private String tradeStatus;
+    private Integer initialPrice;
 }

--- a/src/main/java/org/example/bookmarket/chat/service/ChatService.java
+++ b/src/main/java/org/example/bookmarket/chat/service/ChatService.java
@@ -31,16 +31,22 @@ public interface ChatService {
 
     /**
      * 메시지 삭제
-     * @param messageId 삭제할 메시지 ID
+     *
+     * @param messageId     삭제할 메시지 ID
      * @param currentUserId 현재 로그인한 사용자 ID
      */
     void deleteMessage(Long messageId, Long currentUserId);
 
     /**
      * ✅ [추가] 채팅방 페이지에 필요한 정보를 조회하는 메서드 선언
-     * @param channelId 조회할 채널 ID
+     *
+     * @param channelId     조회할 채널 ID
      * @param currentUserId 현재 로그인한 사용자 ID
      * @return 채팅방 정보(상대방 닉네임, 책 제목 등) DTO
      */
     ChatRoomInfo getChatRoomInfo(Long channelId, Long currentUserId);
+
+    void completeTrade(Long channelId, Integer price, Long currentUserId);
+
+    void cancelTrade(Long channelId, Long currentUserId);
 }

--- a/src/main/java/org/example/bookmarket/common/handler/exception/ErrorCode.java
+++ b/src/main/java/org/example/bookmarket/common/handler/exception/ErrorCode.java
@@ -58,6 +58,7 @@ public enum ErrorCode {
     BOOK_ALREADY_SOLD(HttpStatus.CONFLICT, "이미 판매 완료된 상품입니다."),
     WISHLIST_DUPLICATED(HttpStatus.CONFLICT, "이미 찜한 책입니다."),
     WISHLIST_OWN_BOOK(HttpStatus.CONFLICT, "자신의 판매글은 찜할 수 없습니다."),
+    TRADE_NOT_FOUND(HttpStatus.NOT_FOUND, "거래 정보를 찾을 수 없습니다."),
 
     USED_BOOK_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "판매글을 삭제할 권한이 없습니다.");
 

--- a/src/main/java/org/example/bookmarket/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/org/example/bookmarket/profile/service/ProfileServiceImpl.java
@@ -7,6 +7,7 @@ import org.example.bookmarket.chat.dto.ChatSummary;
 import org.example.bookmarket.chat.entity.ChatMessage;
 import org.example.bookmarket.chat.repository.ChatChannelRepository;
 import org.example.bookmarket.chat.repository.ChatMessageRepository;
+import org.example.bookmarket.chat.entity.ChatChannel;
 import org.example.bookmarket.common.handler.exception.CustomException;
 import org.example.bookmarket.common.handler.exception.ErrorCode;
 import org.example.bookmarket.common.service.S3UploadService;
@@ -17,6 +18,7 @@ import org.example.bookmarket.trade.entity.Trade;
 import org.example.bookmarket.trade.repository.TradeRepository;
 import org.example.bookmarket.usedbook.dto.UsedBookSummary;
 import org.example.bookmarket.usedbook.repository.UsedBookRepository;
+import org.example.bookmarket.usedbook.entity.UsedBook;
 import org.example.bookmarket.user.dto.UserCategoryResponse;
 import org.example.bookmarket.user.entity.User;
 import org.example.bookmarket.user.entity.UserCategory;
@@ -29,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Comparator;
 import java.util.stream.Collectors;
 
 @Service
@@ -106,6 +109,7 @@ public class ProfileServiceImpl implements ProfileService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         return chatChannelRepository.findByUser1OrUser2(user, user).stream()
+                .sorted(Comparator.comparing(ChatChannel::getLastMessageAt).reversed())
                 .map(ch -> {
                     ChatMessage lastMsg = chatMessageRepository
                             .findFirstByChannelOrderBySentAtDesc(ch)
@@ -134,6 +138,7 @@ public class ProfileServiceImpl implements ProfileService {
             throw new CustomException(ErrorCode.USER_NOT_FOUND);
         }
         return usedBookRepository.findBySellerId(userId).stream()
+                .sorted(Comparator.comparing(UsedBook::getUpdatedAt).reversed())
                 .map(ub -> {
                     String buyerNickname = null;
                     if ("판매 완료".equalsIgnoreCase(ub.getStatus()) || "SOLD".equalsIgnoreCase(ub.getStatus())) {
@@ -164,6 +169,7 @@ public class ProfileServiceImpl implements ProfileService {
             throw new CustomException(ErrorCode.USER_NOT_FOUND);
         }
         return tradeRepository.findByBuyerId(userId).stream()
+                .sorted(Comparator.comparing(Trade::getUpdatedAt).reversed())
                 .map(tx -> new PurchaseSummary(
                         tx.getId(),
                         tx.getUsedBook().getBook().getTitle(),

--- a/src/main/java/org/example/bookmarket/trade/entity/Trade.java
+++ b/src/main/java/org/example/bookmarket/trade/entity/Trade.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.example.bookmarket.usedbook.entity.UsedBook;
 import org.example.bookmarket.user.entity.User;
 import org.example.bookmarket.common.TimeEntity;
+import org.example.bookmarket.chat.entity.ChatChannel;
 
 @Entity
 @Table(name = "transaction")
@@ -39,8 +40,7 @@ public class Trade extends TimeEntity {
     @Enumerated(EnumType.STRING)
     private TradeType tradeType;
 
-    private String pickupLocation;
-    private String deliveryAddress;
-    private String buyerContactInfo;
-    private String sellerContactInfo;
+    @OneToOne
+    @JoinColumn(name = "channel_id")
+    private ChatChannel channel;
 }

--- a/src/main/java/org/example/bookmarket/trade/entity/TradeStatus.java
+++ b/src/main/java/org/example/bookmarket/trade/entity/TradeStatus.java
@@ -2,6 +2,6 @@ package org.example.bookmarket.trade.entity;
 
 public enum TradeStatus {
     REQUESTED,
-    CONFIRMED,
-    COMPLETED
+    COMPLETED,
+    CANCELED
 }

--- a/src/main/java/org/example/bookmarket/trade/repository/TradeRepository.java
+++ b/src/main/java/org/example/bookmarket/trade/repository/TradeRepository.java
@@ -9,4 +9,5 @@ public interface TradeRepository extends JpaRepository<Trade, Long> {
     boolean existsByUsedBookIdAndStatusIn(Long usedBookId, List<org.example.bookmarket.trade.entity.TradeStatus> statuses);
     java.util.List<Trade> findByBuyerId(Long buyerId);
     java.util.List<Trade> findBySellerId(Long sellerId);
+    java.util.Optional<Trade> findByChannelId(Long channelId);
 }

--- a/src/main/java/org/example/bookmarket/trade/service/TradeService.java
+++ b/src/main/java/org/example/bookmarket/trade/service/TradeService.java
@@ -1,4 +1,13 @@
 package org.example.bookmarket.trade.service;
 
-public class TradeService {
+import org.example.bookmarket.chat.entity.ChatChannel;
+import org.example.bookmarket.trade.entity.Trade;
+import org.example.bookmarket.usedbook.entity.UsedBook;
+import org.example.bookmarket.user.entity.User;
+
+public interface TradeService {
+    Trade createTrade(ChatChannel channel, UsedBook usedBook, User seller, User buyer);
+    Trade getTradeByChannel(Long channelId);
+    Trade completeTrade(Long tradeId, Integer price);
+    Trade cancelTrade(Long tradeId);
 }

--- a/src/main/java/org/example/bookmarket/trade/service/TradeService.java
+++ b/src/main/java/org/example/bookmarket/trade/service/TradeService.java
@@ -8,6 +8,7 @@ import org.example.bookmarket.user.entity.User;
 public interface TradeService {
     Trade createTrade(ChatChannel channel, UsedBook usedBook, User seller, User buyer);
     Trade getTradeByChannel(Long channelId);
+    java.util.Optional<Trade> findTradeByChannel(Long channelId);
     Trade completeTrade(Long tradeId, Integer price);
     Trade cancelTrade(Long tradeId);
 }

--- a/src/main/java/org/example/bookmarket/trade/service/TradeServiceImpl.java
+++ b/src/main/java/org/example/bookmarket/trade/service/TradeServiceImpl.java
@@ -1,0 +1,60 @@
+package org.example.bookmarket.trade.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.bookmarket.chat.entity.ChatChannel;
+import org.example.bookmarket.common.handler.exception.CustomException;
+import org.example.bookmarket.common.handler.exception.ErrorCode;
+import org.example.bookmarket.trade.entity.Trade;
+import org.example.bookmarket.trade.entity.TradeStatus;
+import org.example.bookmarket.trade.repository.TradeRepository;
+import org.example.bookmarket.usedbook.entity.UsedBook;
+import org.example.bookmarket.user.entity.User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TradeServiceImpl implements TradeService {
+
+    private final TradeRepository tradeRepository;
+
+    @Override
+    @Transactional
+    public Trade createTrade(ChatChannel channel, UsedBook usedBook, User seller, User buyer) {
+        Trade trade = Trade.builder()
+                .channel(channel)
+                .usedBook(usedBook)
+                .seller(seller)
+                .buyer(buyer)
+                .agreedPrice(usedBook.getSellingPrice())
+                .status(TradeStatus.REQUESTED)
+                .build();
+        return tradeRepository.save(trade);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Trade getTradeByChannel(Long channelId) {
+        return tradeRepository.findByChannelId(channelId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRADE_NOT_FOUND));
+    }
+
+    @Override
+    @Transactional
+    public Trade completeTrade(Long tradeId, Integer price) {
+        Trade trade = tradeRepository.findById(tradeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRADE_NOT_FOUND));
+        trade.setAgreedPrice(price);
+        trade.setStatus(TradeStatus.COMPLETED);
+        return trade;
+    }
+
+    @Override
+    @Transactional
+    public Trade cancelTrade(Long tradeId) {
+        Trade trade = tradeRepository.findById(tradeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRADE_NOT_FOUND));
+        trade.setStatus(TradeStatus.CANCELED);
+        return trade;
+    }
+}

--- a/src/main/java/org/example/bookmarket/trade/service/TradeServiceImpl.java
+++ b/src/main/java/org/example/bookmarket/trade/service/TradeServiceImpl.java
@@ -40,12 +40,18 @@ public class TradeServiceImpl implements TradeService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public java.util.Optional<Trade> findTradeByChannel(Long channelId) {
+        return tradeRepository.findByChannelId(channelId);
+    }
+    @Override
     @Transactional
     public Trade completeTrade(Long tradeId, Integer price) {
         Trade trade = tradeRepository.findById(tradeId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TRADE_NOT_FOUND));
         trade.setAgreedPrice(price);
         trade.setStatus(TradeStatus.COMPLETED);
+        trade.getUsedBook().markAsSold();
         return trade;
     }
 

--- a/src/main/java/org/example/bookmarket/usedbook/controller/UsedBookApiController.java
+++ b/src/main/java/org/example/bookmarket/usedbook/controller/UsedBookApiController.java
@@ -1,6 +1,7 @@
 package org.example.bookmarket.usedbook.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.bookmarket.usedbook.dto.UsedBookPostRequest;
 import org.example.bookmarket.book.dto.BookResponse;
 import org.example.bookmarket.book.service.BookService;
 import org.example.bookmarket.usedbook.dto.UsedBookResponse;
@@ -62,6 +63,13 @@ public class UsedBookApiController {
         usedBookPurchaseService.purchase(bookId);
         return ResponseEntity.ok("책 구매에 성공했습니다. ID: " + bookId);
     }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<Void> updateUsedBook(@PathVariable Long id, @RequestBody UsedBookPostRequest request) {
+        usedBookPostService.updateUsedBook(id, request);
+        return ResponseEntity.noContent().build();
+    }
+
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteUsedBook(@PathVariable Long id) {

--- a/src/main/java/org/example/bookmarket/usedbook/entity/UsedBook.java
+++ b/src/main/java/org/example/bookmarket/usedbook/entity/UsedBook.java
@@ -73,6 +73,19 @@ public class UsedBook extends TimeEntity {
             images.forEach(image -> image.setUsedBook(this)); // 양방향 연관관계 설정
         }
     }
+
+    public void setSellingPrice(Integer sellingPrice) {
+        this.sellingPrice = sellingPrice;
+    }
+
+    public void setDetailedCondition(String detailedCondition) {
+        this.detailedCondition = detailedCondition;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
+    }
+
     public void markAsSold() {
         this.status = "판매 완료";
     }

--- a/src/main/java/org/example/bookmarket/usedbook/service/UsedBookPostService.java
+++ b/src/main/java/org/example/bookmarket/usedbook/service/UsedBookPostService.java
@@ -114,8 +114,37 @@ public class UsedBookPostService {
         if (!usedBook.getSeller().getId().equals(currentUser.getId())) {
             throw new CustomException(ErrorCode.USED_BOOK_DELETE_FORBIDDEN);
         }
+        if ("판매 완료".equalsIgnoreCase(usedBook.getStatus()) || "SOLD".equalsIgnoreCase(usedBook.getStatus())) {
+            throw new CustomException(ErrorCode.BOOK_ALREADY_SOLD);
+        }
         usedBookRepository.delete(usedBook);
         log.info("중고책이 삭제되었습니다. ID: {}", usedBookId);
+    }
+
+    @Transactional
+    public void updateUsedBook(Long usedBookId, UsedBookPostRequest request) {
+        User currentUser = getCurrentUser();
+        UsedBook usedBook = usedBookRepository.findById(usedBookId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USED_BOOK_NOT_FOUND));
+        if (!usedBook.getSeller().getId().equals(currentUser.getId())) {
+            throw new CustomException(ErrorCode.USED_BOOK_DELETE_FORBIDDEN);
+        }
+        if ("판매 완료".equalsIgnoreCase(usedBook.getStatus()) || "SOLD".equalsIgnoreCase(usedBook.getStatus())) {
+            throw new CustomException(ErrorCode.BOOK_ALREADY_SOLD);
+        }
+        if (request.getSellingPrice() != null) {
+            usedBook.setSellingPrice(request.getSellingPrice());
+        }
+        if (request.getDetailedCondition() != null) {
+            usedBook.setDetailedCondition(request.getDetailedCondition());
+        }
+        if (request.getCategoryId() != null) {
+            Category category = categoryRepository.findById(request.getCategoryId())
+                    .orElseThrow(() -> new CustomException(ErrorCode.CATEGORY_NOT_FOUND));
+            usedBook.setCategory(category);
+        }
+        usedBookRepository.save(usedBook);
+        log.info("중고책이 수정되었습니다. ID: {}", usedBookId);
     }
 
     /**

--- a/src/main/java/org/example/bookmarket/wishlist/service/WishlistServiceImpl.java
+++ b/src/main/java/org/example/bookmarket/wishlist/service/WishlistServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Comparator;
 import java.util.stream.Collectors;
 
 @Service
@@ -32,6 +33,7 @@ public class WishlistServiceImpl implements WishlistService {
             throw new CustomException(ErrorCode.USER_NOT_FOUND);
         }
         return wishlistRepository.findByUserId(userId).stream()
+                .sorted(Comparator.comparing(Wishlist::getCreatedAt).reversed())
                 .map(this::toDto)
                 .collect(Collectors.toList());
     }

--- a/src/main/resources/templates/book-detail.html
+++ b/src/main/resources/templates/book-detail.html
@@ -95,7 +95,7 @@
             <button id="delete-button" class="min-w-[84px] h-12 px-4 bg-red-600 text-white font-bold rounded-lg hover:bg-red-500"
                     th:if="${book.sellerId == userId}">삭제</button>
             <button id="purchase-button" class="flex-1 min-w-[84px] h-12 px-4 bg-gray-800 text-white font-bold rounded-lg hover:bg-gray-700"
-                    th:if="${book.sellerId != userId}">채팅하기 / 구매 요청</button>
+                    th:if="${book.sellerId != userId and book.status == 'FOR_SALE'}">채팅하기 / 구매 요청</button>
         </div>
     </footer>
 </div>

--- a/src/main/resources/templates/book-detail.html
+++ b/src/main/resources/templates/book-detail.html
@@ -94,15 +94,19 @@
                     th:if="${book.sellerId != userId}">찜하기</button>
             <button id="delete-button" class="min-w-[84px] h-12 px-4 bg-red-600 text-white font-bold rounded-lg hover:bg-red-500"
                     th:if="${book.sellerId == userId}">삭제</button>
+            <button id="edit-button" class="flex-1 min-w-[84px] h-12 px-4 bg-gray-800 text-white font-bold rounded-lg hover:bg-gray-700"
+                    th:if="${book.sellerId == userId}" type="button">수정</button>
             <button id="purchase-button" class="flex-1 min-w-[84px] h-12 px-4 bg-gray-800 text-white font-bold rounded-lg hover:bg-gray-700"
                     th:if="${book.sellerId != userId and book.status == 'FOR_SALE'}">채팅하기 / 구매 요청</button>
         </div>
     </footer>
 </div>
+<div id="flash-message" th:if="${alertMessage}" th:data-msg="${alertMessage}" class="hidden"></div>
 <script th:inline="javascript">
     /*<![CDATA[*/
     const bookId = /*[[${book.id}]]*/ 'default';
     const userId = /*[[${userId}]]*/ null; // 서버에서 주입된 현재 사용자 ID
+    const bookStatus = /*[[${book.status}]]*/ '';
 
     document.addEventListener('DOMContentLoaded', function() {
         const sellerId = /*[[${book.sellerId}]]*/ 0;
@@ -111,12 +115,18 @@
 
         const wishlistButton = document.getElementById('wishlist-button');
         const purchaseButton = document.getElementById('purchase-button');
+        const editButton = document.getElementById('edit-button');
 
         const handleAuthError = () => {
             if (confirm('로그인이 필요합니다. 로그인 페이지로 이동하시겠습니까?')) {
                 window.location.href = '/auth/login';
             }
         };
+
+        const flash = document.getElementById('flash-message');
+        if (flash) {
+            alert(flash.dataset.msg);
+        }
 
         if (wishlistButton) {
             wishlistButton.addEventListener('click', function() {
@@ -143,6 +153,16 @@
                     .catch(error => {
                         alert(error.message);
                     });
+            });
+        }
+
+        if (editButton) {
+            editButton.addEventListener('click', function() {
+                if (bookStatus === 'SOLD' || bookStatus === '판매 완료') {
+                    alert('판매 완료된 글은 수정할 수 없습니다.');
+                } else {
+                    window.location.href = `/used-books/${bookId}/edit`;
+                }
             });
         }
 

--- a/src/main/resources/templates/book-detail.html
+++ b/src/main/resources/templates/book-detail.html
@@ -77,7 +77,7 @@
                     <p class="text-2xl font-bold text-gray-800" th:text="${#numbers.formatInteger(book.sellingPrice, 3, 'COMMA')} + '원'"></p>
                     <div class="flex items-center gap-2">
                         <div class="size-3 rounded-full bg-green-500"></div>
-                        <span class="text-sm font-medium text-green-600"
+                        <span class="text-sm font-medium text-green-600 whitespace-nowrap"
                               th:text="${book.status == 'FOR_SALE' ? '판매중' : (book.status == 'SOLD' || book.status == '판매 완료' ? '판매 완료' : book.status)}">
                             판매중
                         </span>

--- a/src/main/resources/templates/book-detail.html
+++ b/src/main/resources/templates/book-detail.html
@@ -94,7 +94,8 @@
                     th:if="${book.sellerId != userId}">찜하기</button>
             <button id="delete-button" class="min-w-[84px] h-12 px-4 bg-red-600 text-white font-bold rounded-lg hover:bg-red-500"
                     th:if="${book.sellerId == userId}">삭제</button>
-            <button id="purchase-button" class="flex-1 min-w-[84px] h-12 px-4 bg-gray-800 text-white font-bold rounded-lg hover:bg-gray-700">채팅하기 / 구매 요청</button>
+            <button id="purchase-button" class="flex-1 min-w-[84px] h-12 px-4 bg-gray-800 text-white font-bold rounded-lg hover:bg-gray-700"
+                    th:if="${book.sellerId != userId}">채팅하기 / 구매 요청</button>
         </div>
     </footer>
 </div>

--- a/src/main/resources/templates/book-edit.html
+++ b/src/main/resources/templates/book-edit.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <title>판매글 수정 - 북적북적</title>
+    <meta name="_csrf" th:content="${_csrf.token}" />
+    <meta name="_csrf_header" th:content="${_csrf.headerName}" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;700;900&family=Plus+Jakarta+Sans:wght@400;500;700;800&display=swap" />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+</head>
+<body class="relative flex min-h-screen flex-col bg-white" style="font-family: 'Plus Jakarta Sans', 'Noto Sans', sans-serif;">
+<div class="flex flex-col grow layout-container">
+    <div th:replace="~{fragments/header :: header}"></div>
+    <main class="flex-1 flex justify-center px-6 md:px-40 py-6">
+        <div class="w-full max-w-[600px] flex flex-col gap-6">
+            <h1 class="text-2xl font-bold">판매글 수정</h1>
+            <form id="edit-form" class="space-y-4">
+                <div>
+                    <label for="sellingPrice" class="block text-sm font-medium leading-6 text-gray-900">판매 희망 가격 (원)</label>
+                    <input type="number" id="sellingPrice" class="mt-2 block w-full rounded-md border-gray-300" th:value="${book.sellingPrice}" />
+                </div>
+                <div>
+                    <label for="categoryId" class="block text-sm font-medium leading-6 text-gray-900">카테고리</label>
+                    <select id="categoryId" class="mt-2 block w-full rounded-md border-gray-300">
+                        <option th:each="c : ${categories}" th:value="${c.id}" th:text="${c.name}" th:selected="${c.id == book.categoryId}"></option>
+                    </select>
+                </div>
+                <div>
+                    <label for="detailedCondition" class="block text-sm font-medium leading-6 text-gray-900">상세 설명</label>
+                    <textarea id="detailedCondition" rows="3" class="mt-2 block w-full rounded-md border-gray-300" th:text="${book.detailedCondition}"></textarea>
+                </div>
+                <div class="flex justify-end gap-2">
+                    <button type="button" onclick="history.back()" class="px-4 py-2 rounded border">취소</button>
+                    <button type="submit" class="px-4 py-2 bg-gray-800 text-white rounded">저장</button>
+                </div>
+            </form>
+        </div>
+    </main>
+    <div th:replace="~{fragments/footer :: footer}"></div>
+</div>
+<script th:inline="javascript">
+    const csrfToken = '[[${_csrf.token}]]';
+    const csrfHeader = '[[${_csrf.headerName}]]';
+
+    document.getElementById('edit-form').addEventListener('submit', e => {
+        e.preventDefault();
+
+        const payload = {
+            sellingPrice: parseInt(document.getElementById('sellingPrice').value),
+            detailedCondition: document.getElementById('detailedCondition').value,
+            categoryId: parseInt(document.getElementById('categoryId').value)
+        };
+
+        fetch(`/api/used-books/[[${book.id}]]`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json', [csrfHeader]: csrfToken },
+            body: JSON.stringify(payload)
+        })
+            .then(res => {
+                if (res.ok) {
+                    alert('수정되었습니다.');
+                    location.href = `/used-books/[[${book.id}]]`;
+                } else {
+                    alert('수정 실패');
+                }
+            });
+    });
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/chatroom.html
+++ b/src/main/resources/templates/chatroom.html
@@ -44,7 +44,11 @@
     // Thymeleaf에서 받은 변수들을 JS 변수로 초기화
     const channelId = /*[[${channelId}]]*/ 0;
     const currentUserId = /*[[${userId}]]*/ 0;
+    const isSeller = /*[[${isSeller}]]*/ false;
+    let tradeStatus = /*[[${tradeStatus}]]*/ 'REQUESTED';
+    const initialPrice = /*[[${initialPrice}]]*/ 0;
     let lastMessageId = 0;
+
 
     // SockJS와 STOMP 클라이언트 객체 초기화
     const socket = new SockJS("/ws-chat"); // WebSocketConfig에 설정된 엔드포인트
@@ -152,6 +156,33 @@
                 }
             });
     };
+
+    const disableChat = () => {
+        document.getElementById('messageInput').disabled = true;
+        document.getElementById('sendButton').disabled = true;
+        const notice = document.createElement('p');
+        notice.textContent = '더 이상 대화를 나눌 수 없습니다.';
+        document.getElementById('messageArea').appendChild(notice);
+        tradeStatus = 'CLOSED';
+    };
+
+    document.getElementById('completeBtn').addEventListener('click', () => {
+        if (!isSeller) return;
+        const price = prompt('최종 가격을 입력하세요', initialPrice);
+        if (price === null) return;
+        fetch(`/api/chat/channel/${channelId}/complete?price=${price}`, {method:'POST'})
+            .then(res => { if(res.ok) disableChat(); else alert('오류'); });
+    });
+
+    document.getElementById('closeBtn').addEventListener('click', () => {
+        if (!confirm('대화를 종료하시겠습니까?')) return;
+        fetch(`/api/chat/channel/${channelId}/cancel`, {method:'POST'})
+            .then(res => { if(res.ok) disableChat(); else alert('오류'); });
+    });
+
+    if (tradeStatus !== 'REQUESTED') {
+        disableChat();
+    }
     setInterval(pollNewMessages, 3000); // 3초마다 새 메시지 확인
 
     // '전송' 버튼 클릭 이벤트 리스너

--- a/src/main/resources/templates/chatroom.html
+++ b/src/main/resources/templates/chatroom.html
@@ -34,7 +34,7 @@
 
             <div class="flex gap-2">
                 <input id="messageInput" type="text" placeholder="메시지를 입력하세요" class="w-full rounded-lg border border-gray-300 px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
-                <button id="sendButton" class="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-bold hover:bg-blue-700">전송</button>
+                <button id="sendButton" class="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-bold hover:bg-blue-700 disabled:opacity-50">전송</button>
             </div>
         </div>
     </main>
@@ -112,10 +112,10 @@
         textEl.textContent = message.content;
         msgEl.appendChild(textEl);
 
-        if (isMine) {
+        if (isMine && tradeStatus === 'REQUESTED') {
             const delBtn = document.createElement('button');
             delBtn.textContent = '삭제';
-            delBtn.className = 'ml-2 text-xs text-red-500';
+            delBtn.className = 'ml-2 text-xs text-red-500 whitespace-nowrap delete-btn';
             delBtn.addEventListener('click', () => deleteMessage(message.messageId, msgEl));
             msgEl.appendChild(delBtn);
         }
@@ -163,8 +163,13 @@
     };
 
     const disableChat = () => {
-        document.getElementById('messageInput').disabled = true;
-        document.getElementById('sendButton').disabled = true;
+        const input = document.getElementById('messageInput');
+        const sendBtn = document.getElementById('sendButton');
+        input.disabled = true;
+        input.placeholder = '더 이상 대화를 나눌 수 없습니다.';
+        sendBtn.disabled = true;
+        sendBtn.style.opacity = '0.5';
+        document.querySelectorAll('.delete-btn').forEach(btn => btn.remove());
         const notice = document.createElement('p');
         notice.textContent = '더 이상 대화를 나눌 수 없습니다.';
         document.getElementById('messageArea').appendChild(notice);

--- a/src/main/resources/templates/chatroom.html
+++ b/src/main/resources/templates/chatroom.html
@@ -8,6 +8,8 @@
 
     <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+    <meta name="_csrf" th:content="${_csrf.token}" />
+    <meta name="_csrf_header" th:content="${_csrf.headerName}" />
 </head>
 <body class="relative flex min-h-screen flex-col bg-white" style="font-family: 'Plus Jakarta Sans', 'Noto Sans', sans-serif;">
 <div class="flex flex-col grow layout-container">
@@ -48,6 +50,9 @@
     let tradeStatus = /*[[${tradeStatus}]]*/ 'REQUESTED';
     const initialPrice = /*[[${initialPrice}]]*/ 0;
     let lastMessageId = 0;
+    const csrfToken = document.querySelector("meta[name='_csrf']")?.getAttribute("content");
+    const csrfHeader = document.querySelector("meta[name='_csrf_header']")?.getAttribute("content");
+
 
 
     // SockJS와 STOMP 클라이언트 객체 초기화
@@ -147,7 +152,7 @@
     };
 
     const deleteMessage = (messageId, element) => {
-        fetch(`/api/chat/message/${messageId}`, { method: 'DELETE' })
+        fetch(`/api/chat/message/${messageId}`, { method: 'DELETE', headers: { [csrfHeader]: csrfToken } })
             .then(res => {
                 if (res.ok) {
                     element.remove();
@@ -170,13 +175,13 @@
         if (!isSeller) return;
         const price = prompt('최종 가격을 입력하세요', initialPrice);
         if (price === null) return;
-        fetch(`/api/chat/channel/${channelId}/complete?price=${price}`, {method:'POST'})
+        fetch(`/api/chat/channel/${channelId}/complete?price=${price}`, {method:'POST', headers: { [csrfHeader]: csrfToken }})
             .then(res => { if(res.ok) disableChat(); else alert('오류'); });
     });
 
     document.getElementById('closeBtn').addEventListener('click', () => {
         if (!confirm('대화를 종료하시겠습니까?')) return;
-        fetch(`/api/chat/channel/${channelId}/cancel`, {method:'POST'})
+        fetch(`/api/chat/channel/${channelId}/cancel`, {method:'POST', headers: { [csrfHeader]: csrfToken }})
             .then(res => { if(res.ok) disableChat(); else alert('오류'); });
     });
 

--- a/src/main/resources/templates/chatroom.html
+++ b/src/main/resources/templates/chatroom.html
@@ -5,6 +5,8 @@
     <title>채팅방 - 북적북적</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;700;900&family=Plus+Jakarta+Sans:wght@400;500;700;800&display=swap" />
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <meta name="_csrf" th:content="${_csrf.token}" />
+    <meta name="_csrf_header" th:content="${_csrf.headerName}" />
 
     <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
@@ -50,8 +52,8 @@
     let tradeStatus = /*[[${tradeStatus}]]*/ 'REQUESTED';
     const initialPrice = /*[[${initialPrice}]]*/ 0;
     let lastMessageId = 0;
-    const csrfToken = document.querySelector("meta[name='_csrf']")?.getAttribute("content");
-    const csrfHeader = document.querySelector("meta[name='_csrf_header']")?.getAttribute("content");
+    const csrfToken = document.querySelector("meta[name='_csrf']")?.getAttribute('content');
+    const csrfHeader = document.querySelector("meta[name='_csrf_header']")?.getAttribute('content');
 
 
 
@@ -100,27 +102,39 @@
     // 화면에 메시지를 그리는 함수
     const showMessage = (message) => {
         const messageArea = document.getElementById("messageArea");
+        const wrapper = document.createElement("div");
         const msgEl = document.createElement("div");
         const textEl = document.createElement("span");
+        const timeEl = document.createElement("small");
 
         // 내가 보낸 메시지인지 확인
         const isMine = Number(message.senderId) === Number(currentUserId);
 
         // 메시지 스타일 설정
-        msgEl.className = `flex items-center max-w-[70%] px-4 py-2 rounded-lg text-sm shadow ${isMine ? 'bg-blue-100 self-end' : 'bg-gray-100 self-start'}`;
+        wrapper.className = `w-full flex flex-col ${isMine ? 'items-end' : 'items-start'}`;
+
+        msgEl.className = `inline-block max-w-[70%] px-4 py-2 rounded-lg text-sm shadow break-words ${isMine ? 'bg-blue-100' : 'bg-gray-100'}`;
         msgEl.dataset.messageId = message.messageId;
         textEl.textContent = message.content;
         msgEl.appendChild(textEl);
+        wrapper.appendChild(msgEl);
+        // 전송 시간을 표시
+        const time = new Date(message.sentAt).toLocaleTimeString('ko-KR', {
+            hour: '2-digit', minute: '2-digit'
+        });
+        timeEl.textContent = time;
+        timeEl.className = 'text-[10px] text-gray-400 mt-1';
+        wrapper.appendChild(timeEl);
 
         if (isMine && tradeStatus === 'REQUESTED') {
             const delBtn = document.createElement('button');
             delBtn.textContent = '삭제';
-            delBtn.className = 'ml-2 text-xs text-red-500 whitespace-nowrap delete-btn';
-            delBtn.addEventListener('click', () => deleteMessage(message.messageId, msgEl));
-            msgEl.appendChild(delBtn);
+            delBtn.className = 'mt-1 text-xs text-red-500';
+            delBtn.addEventListener('click', () => deleteMessage(message.messageId, wrapper));
+            wrapper.appendChild(delBtn);
         }
 
-        messageArea.appendChild(msgEl);
+        messageArea.appendChild(wrapper);
         messageArea.scrollTop = messageArea.scrollHeight; // 항상 최신 메시지가 보이도록 스크롤
     };
 
@@ -152,7 +166,10 @@
     };
 
     const deleteMessage = (messageId, element) => {
-        fetch(`/api/chat/message/${messageId}`, { method: 'DELETE', headers: { [csrfHeader]: csrfToken } })
+        fetch(`/api/chat/message/${messageId}`, {
+            method: 'DELETE',
+            headers: { [csrfHeader]: csrfToken }
+        })
             .then(res => {
                 if (res.ok) {
                     element.remove();
@@ -170,9 +187,6 @@
         sendBtn.disabled = true;
         sendBtn.style.opacity = '0.5';
         document.querySelectorAll('.delete-btn').forEach(btn => btn.remove());
-        const notice = document.createElement('p');
-        notice.textContent = '더 이상 대화를 나눌 수 없습니다.';
-        document.getElementById('messageArea').appendChild(notice);
         tradeStatus = 'CLOSED';
     };
 

--- a/src/main/resources/templates/profile/dm.html
+++ b/src/main/resources/templates/profile/dm.html
@@ -43,7 +43,7 @@
                             <td class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap" th:text="${dm.partnerNickname}">상대방</td>
                             <td class="px-6 py-4" th:text="${dm.bookTitle}">책 제목</td>
                             <td class="px-6 py-4 text-ellipsis overflow-hidden max-w-[200px]" th:text="${dm.lastMessage}">최근 메시지</td>
-                            <td class="px-6 py-4 whitespace-nowrap" th:text="${#temporals.format(dm.updatedAt, 'yyyy-MM-dd')}">2025-06-26</td>
+                            <td class="px-6 py-4 whitespace-nowrap" th:text="${#temporals.format(dm.updatedAt, 'yyyy-MM-dd HH:mm')}">2025-06-26</td>
                         </tr>
                         </tbody>
                     </table>

--- a/src/main/resources/templates/profile/dm.html
+++ b/src/main/resources/templates/profile/dm.html
@@ -43,7 +43,7 @@
                             <td class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap" th:text="${dm.partnerNickname}">상대방</td>
                             <td class="px-6 py-4" th:text="${dm.bookTitle}">책 제목</td>
                             <td class="px-6 py-4 text-ellipsis overflow-hidden max-w-[200px]" th:text="${dm.lastMessage}">최근 메시지</td>
-                            <td class="px-6 py-4" th:text="${#temporals.format(dm.updatedAt, 'yyyy-MM-dd')}">2025-06-26</td>
+                            <td class="px-6 py-4 whitespace-nowrap" th:text="${#temporals.format(dm.updatedAt, 'yyyy-MM-dd')}">2025-06-26</td>
                         </tr>
                         </tbody>
                     </table>

--- a/src/main/resources/templates/profile/purchases.html
+++ b/src/main/resources/templates/profile/purchases.html
@@ -43,8 +43,8 @@
                         </tr>
                         <tr th:each="item : ${purchases}" class="border-b hover:bg-gray-50">
                             <td class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap" th:text="${item.itemTitle}">책 제목</td> <td class="px-6 py-4" th:text="${#numbers.formatInteger(item.price, 3, 'COMMA')} + '원'">10,000원</td>
-                            <td class="px-6 py-4" th:text="${item.sellerNickname ?: '-'}">판매자</td>
-                            <td class="px-6 py-4" th:text="${#temporals.format(item.updatedAt, 'yyyy-MM-dd')}">2025-06-26</td>
+                            <td class="px-6 py-4 whitespace-nowrap" th:text="${item.sellerNickname ?: '-'}">판매자</td>
+                            <td class="px-6 py-4 whitespace-nowrap" th:text="${#temporals.format(item.updatedAt, 'yyyy-MM-dd')}">2025-06-26</td>
                         </tr>
                         </tbody>
                     </table>

--- a/src/main/resources/templates/profile/sales.html
+++ b/src/main/resources/templates/profile/sales.html
@@ -51,13 +51,13 @@
                             <td class="px-6 py-4">
                    <span th:text="${item.status == 'FOR_SALE' ? '판매중' : (item.status == 'SOLD' || item.status == '판매 완료' ? '판매 완료' : item.status)}"
                          th:classappend="${item.status == '판매 완료' || item.status == 'SOLD'} ? ' bg-green-100 text-green-800' : ' bg-yellow-100 text-yellow-800'"
-                        class="px-2 py-1 text-xs font-medium rounded-full">
+                        class="px-2 py-1 text-xs font-medium rounded-full whitespace-nowrap">
                     판매중
                   </span>
                             </td>
-                            <td class="px-6 py-4" th:text="${item.buyerNickname ?: '-'}">-</td>
-                            <td class="px-6 py-4" th:text="${#temporals.format(item.updatedAt, 'yyyy-MM-dd')}">2025-06-25</td>
-                            <td class="px-6 py-4"><button type="button" class="sales-delete text-red-600" th:data-id="${item.usedBookId}">삭제</button></td>
+                            <td class="px-6 py-4 whitespace-nowrap" th:text="${item.buyerNickname ?: '-'}">-</td>
+                            <td class="px-6 py-4 whitespace-nowrap" th:text="${#temporals.format(item.updatedAt, 'yyyy-MM-dd')}">2025-06-25</td>
+                            <td class="px-6 py-4"><button type="button" class="sales-delete text-red-600 whitespace-nowrap" th:data-id="${item.usedBookId}">삭제</button></td>
                         </tr>
                         </tbody>
                     </table>

--- a/src/main/resources/templates/profile/wishlist.html
+++ b/src/main/resources/templates/profile/wishlist.html
@@ -47,9 +47,9 @@
                                 <a th:href="@{/used-books/{id}(id=${item.usedBookId})}" th:text="${item.title}" class="text-blue-600 hover:underline"></a>
                             </td>
                             <td class="px-6 py-4" th:text="${#numbers.formatInteger(item.price, 3, 'COMMA')} + '원'">8,000원</td>
-                            <td class="px-6 py-4" th:text="${item.sellerNickname ?: '-'}">판매자</td>
-                            <td class="px-6 py-4" th:text="${#temporals.format(item.createdAt, 'yyyy-MM-dd')}">2025-06-26</td>
-                            <td class="px-6 py-4"><button type="button" class="wishlist-remove text-red-600" th:data-id="${item.usedBookId}">삭제</button></td>
+                            <td class="px-6 py-4 whitespace-nowrap" th:text="${item.sellerNickname ?: '-'}">판매자</td>
+                            <td class="px-6 py-4 whitespace-nowrap" th:text="${#temporals.format(item.createdAt, 'yyyy-MM-dd')}">2025-06-26</td>
+                            <td class="px-6 py-4"><button type="button" class="wishlist-remove text-red-600 whitespace-nowrap" th:data-id="${item.usedBookId}">삭제</button></td>
                         </tr>
                         </tbody>
                     </table>


### PR DESCRIPTION
## #️⃣연관된 이슈

#68 

## 📝작업 내용

DM기능에서 이어지는 메인기능 흐름 마무리
- dm채널 생성 후 대화방에 거래완료/대화종료 버튼 추가
- 거래완료 버튼은 판매자만 누를 수 있으며, 누르면 최종 가격 입력 모달 창 생성
- 최종가격 입력이 완료되면 해당 판매글은 거래완료 상태가 되며, dm채널은 닫힘
- 대화종료 버튼을 누르면 dm채널은 닫힘

그 외 편의성 및 추가기능 구현
- 프로필의 목록 정렬을 최신목록이 위에 보이게끔 수정
- 판매글 수정 기능 추가(금액, 설명, 카테고리만 변경 가능, 해당 버튼은 판매자 본인의 판매글에만 보임)
- 닫힌 dm 채널에서 채팅 잠금 및 삭제 불가 기능 추가
- 

## 💬리뷰 요구사항(선택) 및 기타 참고사항

실행 문제 없음



